### PR TITLE
Macro button formatting, and popup messages RegEx change

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -215,10 +215,16 @@ module.exports = new Vue({
       var msgs = [];
 
       for (var i = 0; i < this.state.messages.length; i++) {
+      	
         var text = this.state.messages[i].text;
-        if (!/^#/.test(text)) msgs.push(text);
+        var pattern = /#/;
+        
+        if(pattern.test(text)) {
+         var splitText = text.split("#");
+         for (var j = 0; j < splitText.length; j++) msgs.push(splitText[j]);
+      	}
       }
-
+      
       this.showPopup = msgs.length != 0;
 
       return msgs;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -220,9 +220,10 @@ module.exports = new Vue({
         var pattern = /#/;
         
         if(pattern.test(text)) {
-         var splitText = text.split("#");
-         for (var j = 0; j < splitText.length; j++) msgs.push(splitText[j]);
-      	}
+        	var splitText = text.split("#");
+        	for (var j = 0; j < splitText.length; j++) msgs.push(splitText[j]);
+      	} else {
+      		msgs.push(text)
       }
       
       this.showPopup = msgs.length != 0;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -224,6 +224,7 @@ module.exports = new Vue({
         	for (var j = 0; j < splitText.length; j++) msgs.push(splitText[j]);
       	} else {
       		msgs.push(text);
+      	}	
       }
       
       this.showPopup = msgs.length != 0;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -223,7 +223,7 @@ module.exports = new Vue({
         	var splitText = text.split("#");
         	for (var j = 0; j < splitText.length; j++) msgs.push(splitText[j]);
       	} else {
-      		msgs.push(text)
+      		msgs.push(text);
       }
       
       this.showPopup = msgs.length != 0;

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -126,8 +126,7 @@ html(lang="en")
       h3(slot="header") GCode message
 
       div(slot="body")
-        ul
-          li(v-for="msg in popupMessages", track-by="$index") {{msg}}
+        p(v-for="msg in popupMessages", track-by="$index") {{msg}}
 
       div(slot="footer")
         button.pure-button.button-success(v-if="state.xx != 'HOLDING'",

--- a/src/pug/templates/view-control.pug
+++ b/src/pug/templates/view-control.pug
@@ -116,7 +116,7 @@ script#view-control-template(type="text/x-template")
         v-if="macro.path", @click="run_macro($index + 1)",
         :title="'Run macro ' + ($index + 1) + ' ' + macro.name + '\n' + macro.path",
         :style="{'background-color': macro.color}")
-        | {{($index + 1) + ' ' + macro.name}}
+        | {{macro.name}}
 
       button.pure-button.macro(@click="goto('#settings:macros')",
         title="Go to macro settings")


### PR DESCRIPTION
Removed the index numbers from the macro buttons, and modified the RegEx test for popup messages so that an array can be sent from an M0 message using a # character as an array delimeter.

This should preserve original functionality of showing multiple user messages, but needs to be verified as I'm not sure what triggers multiple user messages from the system.

Post processors must be modified to actually write the M0 array message to GCode.

![toolpath-message](https://user-images.githubusercontent.com/7306696/174681098-9f5f6c71-edb9-45e3-8b62-367d6a47f6cf.jpg)

![macro-buttons](https://user-images.githubusercontent.com/7306696/174681099-2d1dfa18-4189-4262-b936-df56b4836dbe.jpg)