### PR TITLE
Macro style changes.

### DIFF
--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -49,7 +49,8 @@
       font-weight bold
 
     .macro
-      display inline-flex
+      display flex
+      width auto
       flex 1
       align-items center
       background #eee

--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -67,7 +67,7 @@
         user-select normal
 
       .name
-        width auto
+        width 5em
 
       .path
         flex 1

--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -49,7 +49,7 @@
       font-weight bold
 
     .macro
-      display flex
+      display inline-flex
       flex 1
       align-items center
       background #eee

--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -67,7 +67,7 @@
         user-select normal
 
       .name
-        width 5em
+        width auto
 
       .path
         flex 1

--- a/src/stylus/view-control.styl
+++ b/src/stylus/view-control.styl
@@ -165,7 +165,7 @@
 
     .macro
       text-align left
-      overflow visible
+      overflow hidden
       text-overflow ellipsis
       white-space nowrap
       padding 0.5em

--- a/src/stylus/view-control.styl
+++ b/src/stylus/view-control.styl
@@ -165,7 +165,7 @@
 
     .macro
       text-align left
-      overflow hidden
+      overflow visible
       text-overflow ellipsis
       white-space nowrap
       padding 0.5em


### PR DESCRIPTION
The current styles for the macro grid on view-control hide the text overflow for each button.  The change simply makes the entire name visible.

![macros 1](https://user-images.githubusercontent.com/7306696/212499970-76581d14-e815-4087-88f2-d36415aa290f.jpg)

![macros 2](https://user-images.githubusercontent.com/7306696/212499972-617f7012-8896-4b3a-ab88-a1b8782252d7.jpg)

Sorry the pull request isn't clean...