### PR TITLE
Macro button style changes

### DIFF
--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -49,7 +49,8 @@
       font-weight bold
 
     .macro
-      display inline-flex
+      display flex
+      width auto
       flex 1
       align-items center
       background #eee

--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -67,7 +67,7 @@
         user-select normal
 
       .name
-        width auto
+        width 5em
 
       .path
         flex 1

--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -49,7 +49,7 @@
       font-weight bold
 
     .macro
-      display flex
+      display inline-flex
       flex 1
       align-items center
       background #eee

--- a/src/stylus/macros.styl
+++ b/src/stylus/macros.styl
@@ -67,7 +67,7 @@
         user-select normal
 
       .name
-        width 5em
+        width auto
 
       .path
         flex 1

--- a/src/stylus/view-control.styl
+++ b/src/stylus/view-control.styl
@@ -165,7 +165,7 @@
 
     .macro
       text-align left
-      overflow visible
+      overflow hidden
       text-overflow ellipsis
       white-space nowrap
       padding 0.5em

--- a/src/stylus/view-control.styl
+++ b/src/stylus/view-control.styl
@@ -157,11 +157,7 @@
           text-anchor middle
 
   .macros
-    display grid
-    grid-template-columns repeat(8, 1fr)
-    column-gap 1%
-    row-gap 8px
-    padding 0 0.25em
+    display flex-wrap
 
     .macro
       text-align left
@@ -169,6 +165,8 @@
       text-overflow ellipsis
       white-space nowrap
       padding 0.5em
+  		margin: 4px;
+  		width: max-content
 
       &:hover
         background-image button-hover

--- a/src/stylus/view-control.styl
+++ b/src/stylus/view-control.styl
@@ -165,8 +165,8 @@
       text-overflow ellipsis
       white-space nowrap
       padding 0.5em
-  		margin: 4px;
-  		width: max-content
+      margin: 4px;
+      width: max-content
 
       &:hover
         background-image button-hover

--- a/src/stylus/view-control.styl
+++ b/src/stylus/view-control.styl
@@ -165,7 +165,7 @@
 
     .macro
       text-align left
-      overflow hidden
+      overflow visible
       text-overflow ellipsis
       white-space nowrap
       padding 0.5em


### PR DESCRIPTION
What about this version?

It leaves the overflow hidden and sets a button width.

Desktop view:
![desktop-view](https://user-images.githubusercontent.com/7306696/213072455-b55914b5-7938-413b-b5e3-9aa82baa1249.jpg)

Mobile view:
![phone-view](https://user-images.githubusercontent.com/7306696/213072465-6f4a0a08-feb3-4e4f-8b30-6b4292f3fe29.jpg)
