### PR TITLE
Handle expired login while editing settings

### DIFF
--- a/src/js/view-settings.js
+++ b/src/js/view-settings.js
@@ -57,12 +57,16 @@ module.exports = {
       if (this.modified && path[0] != 'settings') {
         cancel()
 
+        let authorized = this.$root.authorized
         let result = await this.$root.open_dialog({
-          header: 'Save settings?',
-          body:   'Changes to the settings have not been saved.  ' +
-                  'Would you like to save them now?',
+          header: authorized ? 'Save settings?' : 'Login required',
+          body:   authorized ?
+            'Changes to the settings have not been saved. Would you like to ' +
+            'save them now?' :
+            'Changes to the settings have not been saved. Log in to save ' +
+            'them, discard them, or stay on this page.',
           width:  '320px',
-          buttons: [
+          buttons: authorized ? [
             {
               text:  'Cancel',
               title: 'Stay on the Settings page.'
@@ -74,13 +78,29 @@ module.exports = {
               title: 'Save settings.',
               class: 'button-success'
             }
+          ] : [
+            {
+              text:  'Cancel',
+              title: 'Stay on the Settings page.'
+            }, {
+              text:  'Discard',
+              title: 'Discard settings changes.'
+            }, {
+              text:  'Login',
+              title: 'Log in and save settings.',
+              class: 'button-success'
+            }
           ]})
 
-        if (result == 'cancel')  return
-        if (result == 'save')    await this.save()
-        if (result == 'discard') await this.discard()
+        if (result == 'cancel') return
+        if (result == 'discard') {
+          await this.discard()
+          return location.hash = path.join(':')
+        }
 
-        location.hash = path.join(':')
+        if (result == 'save' || result == 'login') {
+          if (await this.save()) location.hash = path.join(':')
+        }
       }
     },
 
@@ -114,9 +134,66 @@ module.exports = {
 
 
   methods: {
-    async save() {
-      await this.$api.put('config/save', this.config)
-      this.modified = false
+    async authorize() {
+      if (this.$root.authorized) return true
+      await this.$root.login()
+      return this.$root.authorized
+    },
+
+
+    get_error_message(error, fallback) {
+      let xhr = error && error.xhr
+
+      if (xhr && xhr.response && xhr.response.message)
+        return xhr.response.message
+
+      if (xhr && xhr.responseText) {
+        try {
+          let response = JSON.parse(xhr.responseText)
+          if (response && response.message) return response.message
+        } catch (e) {}
+      }
+
+      if (xhr && xhr.statusText) return xhr.statusText
+      return fallback
+    },
+
+
+    async save(retry = true) {
+      if (!await this.authorize()) return false
+
+      try {
+        await this.$api.put('config/save', this.config, {error() {}})
+        this.modified = false
+        return true
+
+      } catch (error) {
+        let xhr = error && error.xhr
+
+        if (xhr && xhr.status == 401) {
+          this.$root.authorized = false
+
+          if (retry) {
+            let result = await this.$root.open_dialog({
+              header: 'Login required',
+              body: 'Your login session expired. Log in to save settings.',
+              buttons: [
+                {text: 'Cancel'},
+                {text: 'Login', class: 'button-success'}
+              ]
+            })
+
+            if (result == 'login' && await this.authorize())
+              return this.save(false)
+          }
+
+          return false
+        }
+
+        await this.$root.error_dialog('Failed to save settings.\n' +
+          this.get_error_message(error, 'Unable to save configuration.'))
+        return false
+      }
     },
 
 

--- a/src/pug/templates/view-settings.pug
+++ b/src/pug/templates/view-settings.pug
@@ -51,8 +51,10 @@ script#view-settings-template(type="text/x-template")
         bbutton(v-else, @click="$root.login", text="Login", success,
           title="Login to unlock protected settings")
 
-        bbutton(:success="modified", :disabled="!modified", @click="save",
+        bbutton(:success="modified", :disabled="!modified || !$root.authorized",
+          @click="save",
           title="Save settings", text="Save")
 
-    .settings-view(v-if="view", :is="'settings-' + view", :index="index",
-      :config="config", :template="template", :state="state", keep-alive)
+    fieldset.settings-lock(:disabled="!$root.authorized")
+      .settings-view(v-if="view", :is="'settings-' + view", :index="index",
+        :config="config", :template="template", :state="state", keep-alive)

--- a/src/stylus/view-settings.styl
+++ b/src/stylus/view-settings.styl
@@ -44,6 +44,12 @@
     margin-bottom 50px
     padding 0 1em
 
+  .settings-lock
+    border 0
+    margin 0
+    min-width 0
+    padding 0
+
 #settings-admin
   a
     text-decoration none


### PR DESCRIPTION
Test deployment containing this change: http://bbctrl.dyndns.org:8091/

Follow-up draft. Not intended for review until the macro PR is resolved.

This PR fixes Settings behavior when the user is logged out or the login
session expires before saving.

Changes:

- make the Settings page read-only while unauthorized
- disable Save while unauthorized
- keep the leave-page dialog from acting like a failed save succeeded
- prompt for login before retrying an expired-session save
- show the API error message on save failure

Files:

- `src/js/view-settings.js`
- `src/pug/templates/view-settings.pug`
- `src/stylus/view-settings.styl`

Validation:

- `node -c src/js/view-settings.js`
- manual test: lose auth, edit settings, confirm read-only behavior and
  login-before-save flow
